### PR TITLE
Fix explicit_allowdeny check for TYPO3 v12 (#97265)

### DIFF
--- a/Classes/ViewHelpers/AbstractHeadlineViewHelper.php
+++ b/Classes/ViewHelpers/AbstractHeadlineViewHelper.php
@@ -86,7 +86,7 @@ class AbstractHeadlineViewHelper extends AbstractTagBasedViewHelper
             $typeField = $GLOBALS['TCA'][$table]['ctrl']['type'];
             $type = BackendUtility::getRecord($table, $uid, $typeField);
 
-            if (empty($type) || !$this->backendUser->check('explicit_allowdeny', $table . ':' . $typeField . ':' . reset($type) . ':ALLOW')) {
+            if (empty($type) || !$this->backendUser->check('explicit_allowdeny', $table . ':' . $typeField . ':' . reset($type))) {
                 return null;
             }
         }


### PR DESCRIPTION
[BUGFIX] Remove ':ALLOW' suffix from `check()` call for explicit_allowdeny

In TYPO3 v12+, the `BackendUserAuthentication::check('explicit_allowdeny', ...)` method expects a value in the format `table:field:value`, without the `:ALLOW` suffix.

This change aligns the check with the expected format as per the Breaking Change #97265: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-97265-SimplifiedAccessModeSystem.html

Previously:
  $this->backendUser->check('explicit_allowdeny', 'tt_content:CType:textmedia:ALLOW')
Now:
  $this->backendUser->check('explicit_allowdeny', 'tt_content:CType:textmedia')